### PR TITLE
Fixed no comments link for small mobile screens.

### DIFF
--- a/hugo/static/stylesheets/screen.css
+++ b/hugo/static/stylesheets/screen.css
@@ -800,6 +800,17 @@ article header p.meta {
   top: 0;
 }
 
+@media only screen and (max-width: 335px) {
+  article header p.meta a {
+    width: 9em;
+    display: inline-block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    vertical-align: top;
+  }
+}
+
 @media only screen and (min-width: 768px) {
   article header {
     margin-bottom: 1.5em;


### PR DESCRIPTION
Этот коммит правит ссылку на комментарии для маленьких мобильных экранов.

Сейчас так:
![image 1](https://user-images.githubusercontent.com/56569/38478738-310754c4-3bed-11e8-88c7-d09bb89f9333.png)

Будет так:
![image 2](https://user-images.githubusercontent.com/56569/38478747-3e638a70-3bed-11e8-8491-d11e8095bd15.png)
