### PR TITLE
Починено форматирование markdown в Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## скрипты публикации подкаста
 
 - `publisher/make_new_episode.sh` — создает шаблон нового выпуска, берет темы с news.radio-t.com.
-– `publisher/make_new_prep.sh` — создает "Темы для ..." следующего выпуска.
+- `publisher/make_new_prep.sh` — создает "Темы для ..." следующего выпуска.
 - `publisher/upload_mp3.sh` — загружает подкаст во все места, предварительно добавляет mp3 теги и картинку и потом разносит по нодам через внешний ansible контейнер.
 - `publisher/deploy.sh` — добавляет в гит и запускает pull + build на мастер. После этого строит лог чата и очищает темы.
 
@@ -16,4 +16,4 @@
 ## переменные окружения
 
 - `RT_NEWS_ADMIN` user:passwd для news
-– `PODCAST_ARCHIVE_CREDS` user:passwd для sftp архивов
+- `PODCAST_ARCHIVE_CREDS` user:passwd для sftp архивов


### PR DESCRIPTION
До этого была смесь тире и дефисов, из-за чего некоторые строки слипались