### PR TITLE
show full post content in posts list

### DIFF
--- a/hugo/src/scss/app.scss
+++ b/hugo/src/scss/app.scss
@@ -358,11 +358,14 @@ $jumbotron-arc-width: 120%;
 .posts-list {
   .post-podcast-content {
     > * {
-      display: none;
+      //display: none;
     }
     ul:first-of-type {
-      display: block !important;
-      margin: 0;
+      //display: block !important;
+      //margin: 0;
+    }
+    > p:last-child {
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
предлагаю такой вариант решения #72 

плюсы: ничего придумывать не надо, выглядит консистентно с тем, что внутри поста, спонсоры будут рады ссылке на главной

<img width="1067" alt="Screenshot 2019-05-31 at 21 06 37" src="https://user-images.githubusercontent.com/2104054/58728859-1f29df80-83e8-11e9-9d77-1d576bb391e9.png">
