### PR TITLE
update last comments only when navigating to another page

### DIFF
--- a/hugo/src/js/components/LastComments.jsx
+++ b/hugo/src/js/components/LastComments.jsx
@@ -1,5 +1,4 @@
 import http from 'axios';
-import Visibility from 'visibilityjs';
 import locale from 'date-fns/locale/ru';
 import { distanceInWordsStrict, format, parse } from 'date-fns';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -56,10 +55,8 @@ function LastComments() {
 
   useEffect(() => {
     updateComments();
-    if (process.env.NODE_ENV !== 'development') {
-      const visibilityInterval = Visibility.every(60 * 1000, updateComments);
-      return () => Visibility.stop(visibilityInterval);
-    }
+    document.addEventListener('turbolinks:visit', updateComments);
+    return () => document.removeEventListener('turbolinks:visit', updateComments);
   }, [updateComments]);
 
   return <div className="last-comments-list">{comments.map((comment) =>

--- a/hugo/src/js/turbolinks.js
+++ b/hugo/src/js/turbolinks.js
@@ -1,4 +1,18 @@
 import Turbolinks from 'turbolinks';
+import debug from './debug';
+
+const events = [
+  'turbolinks:click',
+  'turbolinks:before-visit',
+  'turbolinks:visit',
+  'turbolinks:request-start',
+  'turbolinks:request-end',
+  'turbolinks:before-cache',
+  'turbolinks:before-render',
+  'turbolinks:render',
+  'turbolinks:load',
+];
+events.forEach(eventName => document.addEventListener(eventName, (e) => debug('turbolinks', e)));
 
 Turbolinks.start();
 


### PR DESCRIPTION
убрал самостоятельное обновление комментариев

будут обновляться только при переходе на другую страницу (по сути такое же поведение, как было до обновления дизайна)

fix #60 