### PR TITLE
Change search label to a button tag

### DIFF
--- a/hugo/layouts/partials/navbar.html
+++ b/hugo/layouts/partials/navbar.html
@@ -13,15 +13,13 @@
       >
         <i class="fas fa-adjust"></i>
       </button>
-      <label
-        type="button"
-        for="page-search-input"
+      <button
         class="icon-btn navbar-btn-search btn btn-outline-secondary m-0"
         data-action="click->search#toggle"
       >
         <i class="fas fa-search"></i>
         <span class="d-none d-lg-inline-block">&nbsp;Поиск</span>
-      </label>
+      </button>
       <button
         type="button"
         class="icon-btn navbar-btn-sidebar-toggle btn btn-outline-secondary ml-lg-1 page-sidebar-toggle"

--- a/hugo/layouts/partials/navbar.html
+++ b/hugo/layouts/partials/navbar.html
@@ -13,13 +13,16 @@
       >
         <i class="fas fa-adjust"></i>
       </button>
-      <button
+      <label
+        type="button"
+        for="page-search-input"
         class="icon-btn navbar-btn-search btn btn-outline-secondary m-0"
         data-action="click->search#toggle"
+        tabindex="0"
       >
         <i class="fas fa-search"></i>
         <span class="d-none d-lg-inline-block">&nbsp;Поиск</span>
-      </button>
+      </label>
       <button
         type="button"
         class="icon-btn navbar-btn-sidebar-toggle btn btn-outline-secondary ml-lg-1 page-sidebar-toggle"

--- a/hugo/src/js/controllers/search_controller.jsx
+++ b/hugo/src/js/controllers/search_controller.jsx
@@ -14,6 +14,7 @@ export default class extends Controller {
 
   toggle() {
     this.element.classList.toggle('search-open');
+    this.element.focus();
   }
 
   initialize() {

--- a/hugo/src/js/controllers/search_controller.jsx
+++ b/hugo/src/js/controllers/search_controller.jsx
@@ -14,7 +14,6 @@ export default class extends Controller {
 
   toggle() {
     this.element.classList.toggle('search-open');
-    this.element.focus();
   }
 
   initialize() {

--- a/hugo/src/scss/_navbar.scss
+++ b/hugo/src/scss/_navbar.scss
@@ -47,7 +47,6 @@
     background-color: $white;
     font-weight: $font-weight-normal;
     padding-left: ($spacer / 1.5);
-    cursor: text !important;
     border-color: transparent !important;
     &:not(:active, :focus, :hover) {
       color: $text-muted;


### PR DESCRIPTION
The reason to change label element to button is that a user can't navigate to it with a keyboard. It's important with accessibility point of view.