### PR TITLE
Hide comments count until initialized

### DIFF
--- a/hugo/src/js/controllers/comments_counter_controller.js
+++ b/hugo/src/js/controllers/comments_counter_controller.js
@@ -22,6 +22,7 @@ export default class extends Controller {
     const callback = (mutations) => {
       mutations.forEach((mutation) => {
         const num = mutation.target;
+        num.parentElement.style.visibility = 'visible';
         const n = parseInt(num.innerText);
         if (isNaN(n)) return;
         num.nextElementSibling.innerHTML = getUnits(n, ['комментарий', 'комментария', 'комментариев']);

--- a/hugo/src/scss/main.scss
+++ b/hugo/src/scss/main.scss
@@ -296,6 +296,7 @@ $jumbotron-arc-width: 120%;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  visibility: hidden;
 }
 .post-time {
   font-size: $smaller-font-size;


### PR DESCRIPTION
Спрятал строку про количество комментариев до инициализации
Помогает с миганием при получении комментариев и при изменении слова `комментариев` в `комментарий` или `комментария`

ping @sw-double 

closed #104 