### PR TITLE
Add Dockerfile for frontend

### DIFF
--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:10-alpine as build
+
+RUN \
+    apk add --update --no-cache tzdata curl openssl git openssh-client python3 ca-certificates && \
+    apk add --no-cache --virtual .build-deps python3-dev && \
+    python3 -m ensurepip && pip3 install --upgrade pip && \
+    pip3 install pytoml mistune && \
+    apk del .build-deps && \
+    cp /usr/share/zoneinfo/EST /etc/localtime && \
+    echo "CDT" > /etc/timezone && date && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir -p /app
+WORKDIR /app
+
+ENV NODE_ENV=development
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY ./ ./
+
+ENV HUGO_VER=0.55.5
+ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_Linux-64bit.tar.gz /tmp/hugo.tar.gz
+RUN \
+    cd /tmp && tar -zxf hugo.tar.gz && ls -la && \
+    cp -fv /tmp/hugo /bin/hugo
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
Идея для обсуждения. Добавить Dockerfile для того что бы запускать front end in development  в Docker. Если этот подход имеет смысл я добавлю docker compose или run command в Readme `docker run -v $PWD/src:/app/src -p 3000:3000 -p 3001:3001 -p 1313:1313 radiot`
WIP 