### PR TITLE
Сделал кнопку для переключения цветовой темы доступной

### DIFF
--- a/hugo/layouts/partials/navbar.html
+++ b/hugo/layouts/partials/navbar.html
@@ -7,6 +7,8 @@
     <div class="navbar-toolbar order-lg-12">
       <button
         type="button"
+        title="Поменять цветовую тему"
+        aria-label="Поменять цветовую тему"
         class="icon-btn switch-theme-btn btn btn-outline-secondary mr-lg-1"
         data-controller="theme"
         data-action="click->theme#toggle"

--- a/hugo/src/scss/main.scss
+++ b/hugo/src/scss/main.scss
@@ -808,5 +808,4 @@ $ripple-scale-out: 3.4;
 }
 .switch-theme-btn {
   border-width: 0 !important;
-  box-shadow: none !important;
 }


### PR DESCRIPTION
Fixes #111
Исправил две меленькие ошибки:

1) Удалил сброс стилей при фокусировке на кнопку смены темы. В данный момент про фокусе на кнопке будет появлятся стандартный `box-shadow` для класса `btn-outline-secondary`

2) Добавил описания кнопке смены темы для озвучивания в программах чтения экрана. 