### PR TITLE
Auto dark theme 

### DIFF
--- a/hugo/src/js/controllers/theme_controller.js
+++ b/hugo/src/js/controllers/theme_controller.js
@@ -1,16 +1,23 @@
 import Controller from '../base_controller';
 
 const titleAttribute = 'data-theme';
-let theme = window.RADIOT_THEME;
-
 export default class extends Controller {
-  toggle() {
-    this.toggleTheme();
+  initialize() {
+    super.initialize();
+
+    if (!this.isSaved()) {
+      window.matchMedia("(prefers-color-scheme: dark)").addListener((e) => {
+        this.setTheme(e.matches ? 'dark' : 'light', false);
+      });
+    }
   }
 
-  getStylesheets() {
-    const styles = document.querySelectorAll(`link[${titleAttribute}][rel~="stylesheet"]`);
-    return [].slice.call(styles);
+  isSaved() {
+    try {
+      return Boolean(localStorage.getItem('theme'));
+    } catch(e) {
+      return false;
+    }
   }
 
   enableStylesheet(link, enable) {
@@ -23,14 +30,16 @@ export default class extends Controller {
     }
   }
 
-  setTheme(theme) {
+  setTheme(theme, save = true) {
     try {
-      localStorage.setItem('theme', theme);
-    } catch (e) {
-      //
-    }
+      if (save) {
+        localStorage.setItem('theme', theme);
+      }
+    } catch (e) {}
 
-    this.getStylesheets().forEach((link) => {
+    const styles = [...document.querySelectorAll(`link[${titleAttribute}][rel~="stylesheet"]`)];
+
+    styles.forEach((link) => {
       this.enableStylesheet(link, link.getAttribute(titleAttribute) === theme);
     });
 
@@ -41,9 +50,7 @@ export default class extends Controller {
     document.dispatchEvent(event);
   }
 
-  toggleTheme() {
-    theme = 'dark' === theme ? 'light' : 'dark';
-
-    this.setTheme(theme);
+  toggle() {
+    this.setTheme(window.RADIOT_THEME === 'dark' ? 'light' : 'dark')
   }
 }

--- a/hugo/src/js/theme-init.js
+++ b/hugo/src/js/theme-init.js
@@ -1,21 +1,24 @@
-(function () {
-  function getPreferredTheme() {
+(function (window, themesList) {
+  const theme = (() => {
     try {
-      return 'dark' === localStorage.getItem('theme') ? 'dark' : 'light';
+      const themeFromStore = localStorage.getItem('theme');
+
+      if (['dark', 'light'].includes(themeFromStore)) {
+        return themeFromStore;
+      }
+
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'light';
     } catch (e) {
-      //
+      return 'light'
     }
+  })();
 
-    return 'light';
-  }
-
-  window.RADIOT_THEME = getPreferredTheme();
-
-  for (const t in window.RADIOT_THEMES) {
-    const active = window.RADIOT_THEME === t;
-    window.RADIOT_THEMES[t].forEach(function (style) {
-      const tag = `<link href="${style}" rel="stylesheet" data-theme="${t}" media="${active ? '' : 'none'}">`;
-      document.writeln(tag);
+  for (const t in themesList) {
+    const active = theme === t;
+    themesList[t].forEach((style) => {
+      document.writeln(`<link href="${style}" rel="stylesheet" data-theme="${t}" media="${active ? '' : 'none'}">`);
     });
   }
-}());
+
+  window.RADIOT_THEME = theme;
+}(window, window.RADIOT_THEMES));


### PR DESCRIPTION
Если пользователь никогда не менял тему сайта, то тема будет выбрана в соответствии с установленной системной темой (если система поддерживает установку темной темы).

Предлагаю пока что сделать такую простейшую штуку. А в будущем подумать о ниже рассказанном, для этого нужна будет иконка, которая покажет автоматический выбор.

В идеальном варианте кнопка выбора темы должна иметь 3 состояния.
1. Автоматически (включается системная тема) – показывается только у тех чья система поддерживает смену темы оформления.
2. Противоположная системной (если на данный момент включена светлая, ставим темную и наоборот)
3. Противоположная предыдущей

Таким образом можно будет переключаться именно в тот режим, который нужен пользователю и не вызывать у него диссонанса. Плюс будет возможность вернуться в автоматический режим.
Пример: https://preactjs.com