### PR TITLE
Чинит верстку описания эпизода в Apple Podcasts

### DIFF
--- a/hugo/data/rss/podcast-archives.xml
+++ b/hugo/data/rss/podcast-archives.xml
@@ -1,11 +1,11 @@
     <item>
       <title><![CDATA[{title}]]></title>
-      <description><![CDATA[{content}]]></description>
+      <description><![CDATA[{description}]]></description>
       <link>{url}</link>
       <guid>{url}</guid>
       <pubDate>{date}</pubDate>
       <itunes:author><![CDATA[Umputun, Bobuk, Gray, Ksenks]]></itunes:author>
-      <itunes:summary><![CDATA[{content}]]></itunes:summary>
+      <itunes:summary><![CDATA[{summary}]]></itunes:summary>
       <itunes:image href="{image}" />
       <enclosure url="http://archive.rucast.net/radio-t/media/{filename}.mp3" type="audio/mp3" />
     </item>

--- a/hugo/data/rss/podcast-torrent.xml
+++ b/hugo/data/rss/podcast-torrent.xml
@@ -1,11 +1,11 @@
     <item>
       <title><![CDATA[{title}]]></title>
-      <description><![CDATA[{content}]]></description>
+      <description><![CDATA[{description}]]></description>
       <link>{url}</link>
       <guid>{url}</guid>
       <pubDate>{date}</pubDate>
       <itunes:author><![CDATA[Umputun, Bobuk, Gray, Ksenks]]></itunes:author>
-      <itunes:summary><![CDATA[{content}]]></itunes:summary>
+      <itunes:summary><![CDATA[{summary}]]></itunes:summary>
       <itunes:image href="{image}" />
       <enclosure url="https://radio-t.com/torrents/{filename}.mp3.torrent" type="application/x-bittorrent" />
     </item>

--- a/hugo/data/rss/podcast.xml
+++ b/hugo/data/rss/podcast.xml
@@ -1,11 +1,11 @@
     <item>
       <title>{title}</title>
-      <description><![CDATA[{content}]]></description>
+      <description><![CDATA[{description}]]></description>
       <link>{fixed_url}</link>
       <guid>{url}</guid>
       <pubDate>{date}</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks</itunes:author>
-      <itunes:summary><![CDATA[{content}]]></itunes:summary>
+      <itunes:summary><![CDATA[{summary}]]></itunes:summary>
       <itunes:image href="{image}" />
       <enclosure url="http://cdn.radio-t.com/{filename}.mp3" type="audio/mp3" length="{filesize}" />
     </item>

--- a/hugo/generate_rss.py
+++ b/hugo/generate_rss.py
@@ -115,9 +115,9 @@ def run():
                 # см. примеры в https://github.com/radio-t/radio-t-site/pull/128
                 # при этом summary надо оставить как есть, т.к. оно показывается в одну строчку и там проблемы с версткой нет
                 post_description_html = markdown(post['data'])
-                rss_description_html = post_description_html\
-                    .replace('<ul>', '<p><em>Темы</em><ul>', 1)\
-                    .replace('</ul>', '</ul></p>', 1)
+                rss_description_html = (post_description_html
+                    .replace('<ul>', '<p><em>Темы</em><ul>', 1)
+                    .replace('</ul>', '</ul></p>', 1))
 
                 item = body.format(title=post['config']['title'], 
                                    description=rss_description_html,

--- a/hugo/generate_rss.py
+++ b/hugo/generate_rss.py
@@ -111,7 +111,17 @@ def run():
                 if feed['count'] < 30 and feed['size'] is True:
                     fsize = get_mp3_size(attr('filename') + ".mp3")
 
-                item = body.format(title=post['config']['title'], content=markdown(post['data']),
+                # добавляем строчку "Темы" в описание эпизода перед списком тем, чтобы верстка списка не ехала в Apple Podcasts,
+                # см. примеры в https://github.com/radio-t/radio-t-site/pull/128
+                # при этом summary надо оставить как есть, т.к. оно показывается в одну строчку и там проблемы с версткой нет
+                post_description_html = markdown(post['data'])
+                rss_description_html = post_description_html\
+                    .replace('<ul>', '<p><em>Темы</em><ul>', 1)\
+                    .replace('</ul>', '</ul></p>', 1)
+
+                item = body.format(title=post['config']['title'], 
+                                   description=rss_description_html,
+                                   summary=post_description_html,
                                    filename=attr('filename'),
                                    filesize=fsize,
                                    fixed_url='{}/{}'.format(mconfig['baseurl'], post['url']).replace("//p", "/p"),


### PR DESCRIPTION
В данный момент верстка плывет в родном приложении подкастов как на iOS так и на macOS:

![Screenshot 2020-02-02 at 22 32 50](https://user-images.githubusercontent.com/1160116/73614433-1ab96480-4610-11ea-9d87-c5c495008b3c.png)

После принятия PR и перегенерации фида станет так:

![Screenshot 2020-02-02 at 23 20 48](https://user-images.githubusercontent.com/1160116/73614743-ebf0bd80-4612-11ea-8fb2-4bb29ca1ce17.png)


Решение в PR довольно костыльное - тупой replace тэга прямо внутри html верстки, - но в данном случае оно good enough: не меняет ничего кроме тега `<description>` rss фида + я попробовал сделать с честным парсингом html верстки с помощью BeautifulSoup и оно по читаемости примерно такое же, только более многословное и с лишней зависимостью.