### PR TITLE
Правит код go паблишера для работы изнутри docker контейнера с вызовом питоновых скриптов

### DIFF
--- a/publisher/app/cmd/upload.go
+++ b/publisher/app/cmd/upload.go
@@ -18,6 +18,9 @@ type Upload struct {
 func (u *Upload) Do(episodeNum int) {
 	mp3file := fmt.Sprintf("%s/rt_podcast%d/rt_podcast%d.mp3", u.Location, episodeNum, episodeNum)
 
+	log.Printf("[INFO] set mp3 tags for %s", mp3file)
+	u.Run("mp3tags set-tags %d", episodeNum)
+
 	log.Printf("[INFO] upload %s to master.radio-t.com", mp3file)
 	u.Run("scp %s umputun@master.radio-t.com:/srv/master-node/var/media/%s", mp3file, path.Base(mp3file))
 

--- a/publisher/app/cmd/upload_test.go
+++ b/publisher/app/cmd/upload_test.go
@@ -6,6 +6,8 @@ import (
 
 func TestUpload_Do(t *testing.T) {
 	ex := &MockExecutor{}
+
+	ex.On("Run", "mp3tags set-tags %d", 123)
 	ex.On("Run", "scp %s umputun@master.radio-t.com:/srv/master-node/var/media/%s", "/tmp/rt_podcast123/rt_podcast123.mp3", "rt_podcast123.mp3")
 	ex.On("Run", `ssh umputun@master.radio-t.com "chmod 644 /data/archive/radio-t/media/%s"`, "rt_podcast123.mp3")
 	ex.On("Run", `ssh umputun@master.radio-t.com "find /srv/master-node/var/media -type f -mtime +60 -mtime -1200 -exec rm -vf '{}' ';'"`)
@@ -19,5 +21,5 @@ func TestUpload_Do(t *testing.T) {
 	}
 
 	d.Do(123)
-	ex.AssertNumberOfCalls(t, "Run", 6)
+	ex.AssertNumberOfCalls(t, "Run", 7)
 }

--- a/publisher/app/main.go
+++ b/publisher/app/main.go
@@ -101,7 +101,7 @@ func runNew(episodeNum int) {
 	if err := prep.MakeShow(episodeNum); err != nil {
 		log.Fatalf("[ERROR] failed to make new podcast #%d, %v", episodeNum, err)
 	}
-	log.Printf("[INFO] created new podcast #%d", episodeNum)
+	log.Printf("[INFO] created new podcast:\n%s/podcast-%d.md", opts.NewShowCmd.Dest, episodeNum)
 }
 
 func runPrep(episodeNum int) {
@@ -114,7 +114,7 @@ func runPrep(episodeNum int) {
 	if err := prep.MakePrep(episodeNum); err != nil {
 		log.Fatalf("[ERROR] failed to make new prep #%d, %v", episodeNum, err)
 	}
-	log.Printf("[INFO] created new prep #%d", episodeNum)
+	log.Printf("[INFO] created new prep:\n%s/prep-%d.md", opts.PrepShowCmd.Dest, episodeNum)
 }
 
 func runUpload(episodeNum int) {

--- a/publisher/app/main.go
+++ b/publisher/app/main.go
@@ -120,6 +120,7 @@ func runPrep(episodeNum int) {
 func runUpload(episodeNum int) {
 	upload := cmd.Upload{
 		Executor: &cmd.ShellExecutor{Dry: opts.Dry},
+		Location: opts.UploadCmd.Location,
 	}
 	upload.Do(episodeNum)
 	log.Printf("[INFO] deployed #%d", episodeNum)


### PR DESCRIPTION
Немного поправлен go код, чтобы заработала команда upload, открывались созданные файлы после make new и make prep. Данный PR связан с [PR#129](https://github.com/radio-t/radio-t-site/pull/129) и принимать их надо если не вместе, то с небольшим промежутком: без этого кода make в 129м не заработает, а upload.go здесь вызывает скрипты, добавленные только в 129м