### PR TITLE
Add support locale config for remark42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ publisher/utils/eyeD3/*.pyc
 .env
 .DS_Store
 publisher/target/
+.idea

--- a/hugo/src/js/components/remark.tsx
+++ b/hugo/src/js/components/remark.tsx
@@ -10,6 +10,7 @@ type Props = {
   id?: string;
   className?: string;
   theme?: RemarkTheme;
+  locale: string;
 };
 
 export default class Remark extends Component<Props> {
@@ -56,11 +57,13 @@ export default class Remark extends Component<Props> {
       page_title: string;
       url?: string;
       theme: RemarkTheme;
+      locale: string,
     } = {
       baseurl: this.props.baseurl || "https://remark42.radio-t.com",
       site_id: this.props.site_id,
       page_title: this.props.page_title,
       theme: this.props.theme || "light",
+      locale: this.props.locale,
     };
 
     if (!remark_config.site_id) {

--- a/hugo/src/js/controllers/comments_embed_controller.jsx
+++ b/hugo/src/js/controllers/comments_embed_controller.jsx
@@ -27,6 +27,7 @@ export default class extends Controller {
       url={'https://radio-t.com' + location.pathname}
       page_title={window.remark_config.page_title}
       theme={theme}
+      locale={window.remark_config.locale}
     />), this.element);
   }
 


### PR DESCRIPTION
It is temporary solution. We should use `embed.js`script from remark42 instead of `copy paste`.
Please don't merge it before https://github.com/umputun/remark42/issues/607 will not be fixed.