### PR TITLE
fix(security): Add rel=noopener to external links

### DIFF
--- a/hugo/src/js/turbolinks.js
+++ b/hugo/src/js/turbolinks.js
@@ -24,6 +24,7 @@ document.addEventListener('theme:change', function () {
 document.addEventListener('turbolinks:load', () => {
   [].forEach.call(document.links, link => {
     if (link.hostname !== window.location.hostname) {
+      link.rel = link.rel.length ? link.rel + ' noopener' : 'noopener';
       link.target = '_blank';
     }
   });


### PR DESCRIPTION
Зачем:
Вкладки, запущенные через  `target="_blank"` имеют доступ к запустившей их вкладке через `window.opener` и могут через `window.opener.location` подменить адрес исходной вкладки, атрибут `rel` со значением `noopener` предотвращает доступ через `window.opener`.