### PR TITLE
fix issue #131

### DIFF
--- a/hugo/src/scss/_navbar.scss
+++ b/hugo/src/scss/_navbar.scss
@@ -18,7 +18,7 @@
     }
     .nav-link {
       position: relative;
-      padding: ($spacer * 2) ($spacer / 2) !important;
+      padding: ($spacer * 2) ($spacer / 3) !important;
       &:after {
         content: '';
         position: absolute;

--- a/hugo/src/scss/_search.scss
+++ b/hugo/src/scss/_search.scss
@@ -29,6 +29,7 @@ label[for="page-search-input"] {
   }
 }
 .search-open {
+  position: fixed;
   .page-search {
     display: block;
   }


### PR DESCRIPTION
По поводу применения оверлея при открытии поиска, не блокируя прокрутку основного контента по оси ординат, мягко говоря - моветон.
Переполнение контентом основного навигационного меню было предварительно не продумано, но небольшой костыль поправит дело. А так же чтобы предлоги не отваливались в дальнейшем, можно использовать неразрывные пробелы (\&nbsp;).