### PR TITLE
Add small improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install Latest Docker
+        run: |
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+          sudo apt-get update
+          sudo apt-get install docker-ce
       - name: Docker daemon info
-        run: docker version
+        run: docker info
       - name: build docker image
         run: docker build -t radio-t-site .
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Docker daemon info
+        run: docker version
       - name: build docker image
-        run: docker build .
+        run: docker build -t radio-t-site .
+        env:
+          DOCKER_BUILDKIT: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,11 @@ RUN \
 COPY --from=build /app/static/build/ /app/static/build/
 COPY --from=build /app/data/manifest.json /app/data/manifest.json
 
+## COPY --chmod=0755 exec.sh /srv/exec.sh worked for docker CE >= 20.10
 ## Implemented at https://github.com/moby/buildkit/pull/1492
+## Current version of docker daemon in Github Actions is 19.03.13+azure
 COPY --chmod=0755 exec.sh /srv/exec.sh
+# COPY exec.sh /srv/exec.sh
 # RUN chmod +x /srv/exec.sh
 
 CMD ["/srv/exec.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:10-alpine as build
 
-RUN mkdir -p /app
 WORKDIR /app
 
 COPY hugo/package.json hugo/package-lock.json ./
@@ -35,7 +34,8 @@ RUN \
 COPY --from=build /app/static/build/ /app/static/build/
 COPY --from=build /app/data/manifest.json /app/data/manifest.json
 
-COPY exec.sh /srv/exec.sh
-RUN chmod +x /srv/exec.sh
+## Implemented at https://github.com/moby/buildkit/pull/1492
+COPY --chmod=0755 exec.sh /srv/exec.sh
+# RUN chmod +x /srv/exec.sh
 
 CMD ["/srv/exec.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,6 @@ RUN \
 COPY --from=build /app/static/build/ /app/static/build/
 COPY --from=build /app/data/manifest.json /app/data/manifest.json
 
-## COPY --chmod=0755 exec.sh /srv/exec.sh worked for docker CE >= 20.10
-## Implemented at https://github.com/moby/buildkit/pull/1492
-## Current version of docker daemon in Github Actions is 19.03.13+azure
 COPY --chmod=0755 exec.sh /srv/exec.sh
-# COPY exec.sh /srv/exec.sh
-# RUN chmod +x /srv/exec.sh
 
 CMD ["/srv/exec.sh"]


### PR DESCRIPTION
- add using option `--chmod` for instrunction COPY. Implemented here at https://github.com/moby/buildkit/pull/1492 and worked for versions of docker daemon >= 20.10. Default version of docker daemon in ci is `19.03.13+azure`, so i add installing of latest version docker in ci workflow file
- Delete mkdir before WORKDIR because `WORKDIR` automatically create folder if she doesn't exist