### PR TITLE
Add experimental URL timestamp functionality

### DIFF
--- a/hugo/layouts/partials/player.html
+++ b/hugo/layouts/partials/player.html
@@ -75,6 +75,10 @@
         </div>
       </div>
 
+      <div class="d-flex">
+        <button class="btn btn-link" data-action="player#getLinkToPosition">🔗</button>
+      </div>
+
       <div class="d-flex align-items-center justify-content-center player-rate">
         <button class="btn btn-link" data-action="player#togglePlaybackRate" data-target="player.rate">1</button>
       </div>

--- a/hugo/src/js/controllers/page_controller.js
+++ b/hugo/src/js/controllers/page_controller.js
@@ -1,10 +1,16 @@
 import Controller from '../base_controller';
+import {addTimeToURL} from '../utils'
 
 export default class extends Controller {
+  static state = {
+    URLTime: null,
+  };
+
   static targets = ['player', 'playerStateReceiver'];
 
   initialize() {
     super.initialize();
+    this.getURLTimecode();
   }
 
   updatePodcasts() {
@@ -14,6 +20,12 @@ export default class extends Controller {
   }
 
   playPodcast({ detail }) {
+    // set playback position from ?t=00:00:00 if present
+    if (this.constructor.state.URLTime) {
+      detail.timeLabel = this.constructor.state.URLTime;
+      Object.assign(this.constructor.state, { "URLTime": null });
+      addTimeToURL(detail.url, detail.timeLabel);
+    }
     this.getPlayerController().playPodcast(detail);
   }
 
@@ -22,5 +34,14 @@ export default class extends Controller {
    */
   getPlayerController() {
     return this.application.getControllerForElementAndIdentifier(this.playerTarget, 'player');
+  }
+
+  getURLTimecode() {
+    let searchParams = new URLSearchParams(window.location.search);
+    let timeFromUrl = searchParams.get("t");
+    let timeRegExp = new RegExp(/[0-9]*:?[0-9]:?[0-9]+/m);
+    if (timeRegExp.test(timeFromUrl)) {
+      Object.assign(this.constructor.state, { "URLTime": timeFromUrl });
+    }
   }
 }

--- a/hugo/src/js/controllers/podcast_controller.js
+++ b/hugo/src/js/controllers/podcast_controller.js
@@ -1,5 +1,6 @@
 import Controller from '../base_controller';
 import Player from './player_controller';
+import { addTimeToURL } from '../utils'
 
 /**
  * @property playButtonTarget
@@ -52,6 +53,8 @@ export default class extends Controller {
   }
 
   goToTimeLabel(e) {
+    // add each seek time to URL as t?=00:00:00
+    this.podcastAddTimeToURL(e);
     this.play(e, e.target.textContent);
   }
 
@@ -62,5 +65,10 @@ export default class extends Controller {
       image: this.coverTarget.style.backgroundImage,
       number: this.numberTarget.textContent,
     };
+  }
+
+  podcastAddTimeToURL(e) {
+    let podcastPathname = this.data.get('url');
+    addTimeToURL(podcastPathname, e.target.textContent);
   }
 }

--- a/hugo/src/js/utils.js
+++ b/hugo/src/js/utils.js
@@ -22,8 +22,8 @@ export function getUnits(value, units) {
   return /^[0,2-9]?[1]$/.test(value)
     ? units[0]
     : /^[0,2-9]?[2-4]$/.test(value)
-    ? units[1]
-    : units[2];
+      ? units[1]
+      : units[2];
 }
 
 // 00:02:24 => 144
@@ -48,4 +48,24 @@ export function getTextSnippet(html) {
   const snippet = result.substr(0, LENGTH);
 
   return snippet.length === LENGTH && result.length !== LENGTH ? `${snippet}...` : snippet;
+}
+
+//https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
+export function copyTextToClipboard(text) {
+  if (!navigator.clipboard) {
+    fallbackCopyTextToClipboard(text);
+    return;
+  }
+  navigator.clipboard.writeText(text).then(function () {
+    alert('Временная метка скопирована в буфер обмена\nTO DO: сделать красивое оповещение');
+  }, function (err) {
+    alert('ОШИБКА: невозможно скопировать временную метку в буфер обмена    ', err, "\nTO DO: сделать красивое оповещение");
+  });
+}
+
+export function addTimeToURL(podcastPathname, currentTime) {
+  // add full link to URL
+  if (window.history.pushState) {
+    window.history.pushState(null, null, [podcastPathname, "?t=", currentTime].join(""));
+  }
 }


### PR DESCRIPTION
!!! Не коммитить в мастер !!!

К предложенному в https://github.com/radio-t/radio-t-site/issues/212

Реализовано:

- Доступ по ссылке например переход по https://radio-t.com/p/2021/02/27/podcast-743?t=01:02:03 перейдет на страницу подкаста при нажатии плей плеер автоматически перемотает на выбранное место. 
- В меню воспроизведения добавлена кнопка дать ссылку. При нажатии копирует ссылку на текущее место воспроизведения в буфер обмена если возможно и вставляет в строку адреса если возможно. Кнопка криво отображается на мобилках, но пока что так.
-  При любом нажатии на паузу или на выбор новости по ссылке адрес добавляется в строку адреса. Оказалось не так уж и удобно переходить по истории браузера можно, но приходится каждый раз нажимать кнопку плей. Так как автовоспроизведение браузер блокирует.  Еще отловил фичу браузера что при слишком частом добавлении ссылок в строку  адреса и соответственно в историю браузера, браузер блокирует эту функциональность как слишком частый запрос. Для пользователя это выглядит как просто ничего не работает. Про блокировку можно узнать только в консоли браузера.  

Нужна обратная связь =)