### PR TITLE
Используем длину файла для выставления времени завершения последней главы в mp3 тэгах

### DIFF
--- a/publisher/invoke.yaml
+++ b/publisher/invoke.yaml
@@ -11,4 +11,3 @@ tags:
   title: "Радио-Т ${episode_num}"
 toc:
   first_mp3_chapter_name: "Вступление"
-  max_episode_hours: 4

--- a/publisher/tasks/mp3_tags.py
+++ b/publisher/tasks/mp3_tags.py
@@ -29,7 +29,7 @@ def print_mp3_tags(c, path):
         sys.exit(1)
 
     print_album_meta(tag)
-    print('ID3 tag header version:', '.'.join(map(str, tag.header.version)))
+    print("ID3 tag header version:", ".".join(map(str, tag.header.version)))
     print_toc(tag)
 
 
@@ -55,7 +55,9 @@ def set_mp3_tags(c, path, dry=False, verbose=False):
     episode_page_path = f"/srv/hugo/content/posts/podcast-{episode_num}.md"
     if not os.path.exists(episode_page_path):
         print(
-            "Error:", f'New episode page "{episode_page_path}" does not exists', file=sys.stderr,
+            "Error:",
+            f'New episode page "{episode_page_path}" does not exists',
+            file=sys.stderr,
         )
         sys.exit(1)
 
@@ -69,6 +71,7 @@ def set_mp3_tags(c, path, dry=False, verbose=False):
     episode_file.initTag(version=id3.ID3_V2_3)
 
     tag = episode_file.tag
+    episode_length_secs = int(episode_file.info.time_secs)  # eyed3 returns episode length in float
 
     try:
         print("Creating new album meta tags: title, cover, artists, etc...")
@@ -77,7 +80,7 @@ def set_mp3_tags(c, path, dry=False, verbose=False):
 
         print("Parsing episode articles from markdown template for the episode page in `/hugo/content/posts/`...")
 
-        toc = parse_table_of_contents_from_md(episode_page_path, c.toc.first_mp3_chapter_name, c.toc.max_episode_hours)
+        toc = parse_table_of_contents_from_md(episode_page_path, c.toc.first_mp3_chapter_name, episode_length_secs)
 
         print("Generating table of contents...")
 
@@ -103,7 +106,9 @@ def _get_episode_mp3_full_path(path):
     """
     if not os.path.exists(EPISODES_DIRECTORY):
         print(
-            "Error:", f'Directory "{EPISODES_DIRECTORY}" does not exists', file=sys.stderr,
+            "Error:",
+            f'Directory "{EPISODES_DIRECTORY}" does not exists',
+            file=sys.stderr,
         )
         sys.exit(1)
 

--- a/publisher/utils/episode_posts.py
+++ b/publisher/utils/episode_posts.py
@@ -17,7 +17,7 @@ class Chapter:
     end: int  # end of chapter offset, seconds
 
 
-def parse_table_of_contents_from_md(filename: str, first_chapter_name: str, max_episode_hours: int) -> List[Chapter]:
+def parse_table_of_contents_from_md(filename: str, first_chapter_name: str, episode_length_secs: int) -> List[Chapter]:
     """
     Parse table of contents for episode from Hugo template for this episode post
     """
@@ -53,8 +53,8 @@ def parse_table_of_contents_from_md(filename: str, first_chapter_name: str, max_
         if index + 1 < len(articles):
             end = articles[index + 1][1]
         else:
-            # set last chapter end at estimated end of the episode
-            end = max_episode_hours * 60 * 60
+            # set last chapter end at total duration of the mp3 file
+            end = episode_length_secs
 
         result.append(Chapter(element_id=new_id(index), title=article, start=start * 1000, end=end * 1000))
 


### PR DESCRIPTION
В комментариях к issue https://github.com/radio-t/radio-t-site/issues/39#issuecomment-609459209 @rakleed упомянул проблему отображения некорректного времени завершения последней части эпизода в оглавлении (выпуск отображается с длинной в районе 2х часов, время завершение последней части в тегах отображается как 4:00:00).

Это оглавление собирается из файла с темами выпусков, где есть лишь таймстамп перехода на новую тему, без времени ее завершения, потому год назад, когда я писал код для их сбора, я захардкодил время финальной главы в 4 часа для простоты.

Данный PR будет использовать вместо хардкода время окончания mp3 файла выпуска (время читается с помощью уже используемой в коде библиотеки `eyed3`), что позволит точно синхронизировать завершение последней главы с длинной выпуска отображаемой в подкаст-приложениях и избежать дальнейшей конфузии среди слушателей.