### PR TITLE
Remove Google Play Music link from feeds

### DIFF
--- a/hugo/layouts/pages/feeds.html
+++ b/hugo/layouts/pages/feeds.html
@@ -54,17 +54,6 @@
             <div class="feeds-list-item p-3 border rounded flex-fill">
               <div class="text-right text-primary">
                 <svg width="18" height="18" viewBox="0 0 512 512">
-                  <use xlink:href="#icon-google-play" />
-                </svg>
-              </div>
-              <h3><a href="https://play.google.com/music/m/Ivrwbk7epyisvafnu45f3zp57oi?t=-">Google Play Music</a></h3>
-              <div class="small">Подписка в сервисе</div>
-            </div>
-          </div>
-          <div class="col-md-4 col-sm-6 mb-4 d-flex align-items-stretch flex-row">
-            <div class="feeds-list-item p-3 border rounded flex-fill">
-              <div class="text-right text-primary">
-                <svg width="18" height="18" viewBox="0 0 512 512">
                   <use xlink:href="#icon-spotify" />
                 </svg>
               </div>


### PR DESCRIPTION
Google Play Music был убит 21 месяц назад. Можно уже снять труп поверженного врага с дисплея?
Если где-то там хранится иконка сервиса, то я не искал.