### PR TITLE
Disable double tap to zoom on player controls

### DIFF
--- a/hugo/src/scss/_player.scss
+++ b/hugo/src/scss/_player.scss
@@ -70,6 +70,7 @@ $podcast-player-cover-margin: 0.5rem;
   }
 }
 .btn-player-icon {
+  touch-action: manipulation;
   display: inline-flex;
   padding: 0.25em;
   margin: auto;
@@ -110,6 +111,7 @@ $podcast-player-cover-margin: 0.5rem;
   min-width: $podcast-player-cover-size;
 }
 .player-rate {
+  touch-action: manipulation;
   min-width: 60px;
   text-align: center;
   font-weight: 600;


### PR DESCRIPTION
Disables double tap to zoom on player controls on mobile devices

<img width="464" alt="Screenshot 2024-01-03 at 21 25 57" src="https://github.com/radio-t/radio-t-site/assets/884649/653062cd-237a-4736-bee4-f19939fdd3c0">
