### PR TITLE
Multiple improvements to the frontend code

### DIFF
--- a/.github/workflows/ci-frontend-check.yml
+++ b/.github/workflows/ci-frontend-check.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_JOB_NUMBER: 1
-      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN npm ci --omit=dev --omit optional
 ARG DO_NOT_MINIFY
 
 ENV NODE_ENV=production
-# needed only for old webpack version
-ENV NODE_OPTIONS=--openssl-legacy-provider
 
 COPY ./hugo/webpack.mix.js ./hugo/tsconfig.json ./hugo/.babelrc.js /app/
 COPY ./hugo/src/ /app/src/

--- a/hugo/.gitignore
+++ b/hugo/.gitignore
@@ -4,3 +4,4 @@ dev/
 golayouts/
 .netlify
 .direnv/
+.hugo_build.lock

--- a/hugo/package-lock.json
+++ b/hugo/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^0.28.1",
         "axios-extensions": "^3.1.3",
         "bootstrap": "^4.6.2",
+        "buffer": "^6.0.3",
         "core-js": "^3.1.4",
         "cross-env": "^5.2.0",
         "custom-event-polyfill": "^1.0.7",
@@ -3509,6 +3510,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3872,10 +3897,9 @@
       "dev": true
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -3892,7 +3916,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -21586,6 +21610,18 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "bluebird": {
@@ -21893,13 +21929,12 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {

--- a/hugo/package.json
+++ b/hugo/package.json
@@ -21,6 +21,7 @@
     "axios": "^0.28.1",
     "axios-extensions": "^3.1.3",
     "bootstrap": "^4.6.2",
+    "buffer": "^6.0.3",
     "core-js": "^3.1.4",
     "cross-env": "^5.2.0",
     "custom-event-polyfill": "^1.0.7",


### PR DESCRIPTION
- Add explicit installation of buffer for webpack update
- Ignore `.hugo_build.lock` file which should not be committed.
- Get rid of `openssl-legacy-provider` flag as it it not needed since d6109272947c6f3df492a421b8f87014468c7c24