### PR TITLE
Don't fail compare CI with insufficient permissions to comment

### DIFF
--- a/.github/workflows/ci-build-site.yml
+++ b/.github/workflows/ci-build-site.yml
@@ -277,6 +277,7 @@ jobs:
       - name: Create or update comment
         if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
+        continue-on-error: true
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
CI shouldn't be red here after this change: https://github.com/radio-t/radio-t-site/pull/445, https://github.com/radio-t/radio-t-site/actions/runs/12147178468/job/33892282154?pr=445