### PR TITLE
Add open-pull-requests-limit to NPM dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
     directory: "/hugo"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     groups:
       "NPM modules updates":
         dependency-type: "production"


### PR DESCRIPTION
## Summary
- Added open-pull-requests-limit: 0 to NPM package ecosystem configuration to disable automatic PRs for NPM modules

## Test plan
- Verify that dependabot no longer creates automatic PRs for NPM modules

🤖 Generated with [Claude Code](https://claude.ai/code)