### PR TITLE
Get rid of get.options as we use only params

### DIFF
--- a/hugo/src/js/components/LastComments.jsx
+++ b/hugo/src/js/components/LastComments.jsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
-import http from '../http-get';
+import { fetchJSON } from '../http-get';
 import locale from 'date-fns/locale/ru';
 import { formatDistanceToNowStrict, format, parseISO } from 'date-fns';
 import { getTextSnippet } from '../utils';
@@ -57,9 +57,7 @@ function LastComments() {
 
   const updateComments = useCallback(async () => {
     try {
-      const { data } = await http.get('https://remark42.radio-t.com/api/v1/last/30', {
-        params: { site: 'radiot' },
-      });
+      const data = await fetchJSON('https://remark42.radio-t.com/api/v1/last/30?site=radiot');
       setComments(data);
     } catch (e) {
       //

--- a/hugo/src/js/controllers/avatars_controller.js
+++ b/hugo/src/js/controllers/avatars_controller.js
@@ -4,7 +4,7 @@ import filter from 'lodash/filter';
 import lozad from 'lozad';
 import imagesLoaded from 'imagesloaded';
 import Controller from '../base_controller';
-import http from '../http-get';
+import { fetchJSON } from '../http-get';
 
 const limit = 30;
 
@@ -14,7 +14,7 @@ export default class extends Controller {
     lozad(this.element, {
       load: async () => {
         this.element.classList.add('loaded');
-        const { data } = await this.getComments();
+        const data = await this.getComments();
         const pictures = uniq(filter(map(data.comments, 'user.picture'))).reverse();
         this.element.innerHTML = '';
         pictures.slice(0, limit).forEach((picture, index) => {
@@ -34,10 +34,10 @@ export default class extends Controller {
     }).observe();
   }
 
-  getComments() {
+  async getComments() {
     const url = this.data.get('url');
 
-    return http.get(
+    return fetchJSON(
       `https://remark42.radio-t.com/api/v1/find?url=https://radio-t.com${url}&sort=-time&site=radiot&view=user`
     );
   }

--- a/hugo/src/js/controllers/search_controller.jsx
+++ b/hugo/src/js/controllers/search_controller.jsx
@@ -4,7 +4,7 @@ import locale from 'date-fns/locale/ru';
 import debounce from 'lodash/debounce';
 import Mark from 'mark.js';
 import Controller from '../base_controller';
-import http from '../http-get';
+import { fetchJSON } from '../http-get';
 
 const Results = function ({ results }) {
   return (
@@ -72,9 +72,7 @@ export default class extends Controller {
 
   makeSearchRequest = debounce(async (query) => {
     if (this.searchQuery !== query) return;
-    const { data } = await http.get('https://radio-t.com/site-api/search', {
-      params: { q: query },
-    });
+    const data = await fetchJSON(`https://radio-t.com/site-api/search?q=${encodeURIComponent(query)}`);
     if (this.searchQuery !== query) return;
     this.destroy();
     this.scrollTarget.scrollTo(0, 0);

--- a/hugo/src/js/http-get.js
+++ b/hugo/src/js/http-get.js
@@ -2,27 +2,12 @@ const cache = new Map();
 const throttleMap = new Map();
 
 /**
- * Fetch wrapper with basic caching and throttling
+ * Fetch JSON from URL with caching and throttling
  * @param {string} url - URL to fetch
- * @param {Object} options - Fetch options
  * @returns {Promise<any>} - Promise with parsed JSON response
  */
-async function fetchWithCache(url, options = {}) {
-  // Handle params if present
-  if (options.params) {
-    const urlObj = new URL(url);
-    Object.entries(options.params).forEach(([key, value]) => {
-      urlObj.searchParams.append(key, value);
-    });
-    url = urlObj.toString();
-    // Remove params from options to avoid duplication
-    delete options.params;
-  }
-
-  // sort options to make sure the cache key is consistent
-  const cacheKey = url + (Object.keys(options).length ? `-${JSON.stringify(Object.keys(options).sort().reduce((acc, key) => ({
-    ...acc, [key]: options[key]
-  }), {}))}` : '');
+export async function fetchJSON(url) {
+  const cacheKey = url;
 
   if (throttleMap.has(cacheKey)) {
     return throttleMap.get(cacheKey);
@@ -34,7 +19,7 @@ async function fetchWithCache(url, options = {}) {
 
   const promise = (async () => {
     try {
-      const response = await fetch(url, options);
+      const response = await fetch(url, { method: 'GET' });
 
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -54,12 +39,3 @@ async function fetchWithCache(url, options = {}) {
 
   return promise;
 }
-
-export default {
-  get: async (url, options = {}) => {
-    const data = await fetchWithCache(url, {
-      method: 'GET', ...options
-    });
-    return {data};
-  }
-};


### PR DESCRIPTION
Addressing this comment from @alexeyten:

> Browser's `fetch` doesn't have `options.params` parameter, so it will not work as a drop-in replacement

We can simplify the code as there are no other options than url parameters ever passed to this function.