### PR TITLE
Fix golangci-lint shadow

### DIFF
--- a/publisher/.golangci.yml
+++ b/publisher/.golangci.yml
@@ -7,7 +7,8 @@ run:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   golint:
     min-confidence: 0.1
   maligned:


### PR DESCRIPTION
This causes golangci-lint config validation errors