### PR TITLE
Configure Dependabot to only provide security updates for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
     groups:
       "Go modules updates":
         dependency-type: "production"
+        applies-to: "security-updates"
   - package-ecosystem: "gomod"
     directory: "/publisher"
     schedule:
@@ -27,6 +28,7 @@ updates:
     groups:
       "Go modules updates":
         dependency-type: "production"
+        applies-to: "security-updates"
   - package-ecosystem: "npm"
     directory: "/hugo"
     schedule:


### PR DESCRIPTION
This change modifies the Dependabot configuration to only provide security updates for Go packages, eliminating regular version updates that can be noisy.