### PR TITLE
Configure Dependabot to only provide security updates for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/rss_generator"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       "Go modules updates":
         dependency-type: "production"
@@ -24,7 +24,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/publisher"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       "Go modules updates":
         dependency-type: "production"


### PR DESCRIPTION
This change modifies the Dependabot configuration to only provide security updates for Go packages, eliminating regular version updates that can be noisy.