### PR TITLE
Update Dependabot configuration to stop automatic PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,37 +5,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    groups:
-      "GitHub Actions updates":
-        patterns:
-          - "*"
   - package-ecosystem: "gomod"
     directory: "/rss_generator"
     schedule:
       interval: "weekly"
-    groups:
-      "Go modules updates":
-        dependency-type: "production"
-        applies-to: "security-updates"
+    open-pull-requests-limit: 0
   - package-ecosystem: "gomod"
     directory: "/publisher"
     schedule:
       interval: "weekly"
-    groups:
-      "Go modules updates":
-        dependency-type: "production"
-        applies-to: "security-updates"
+    open-pull-requests-limit: 0
   - package-ecosystem: "npm"
     directory: "/hugo"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 0
-    groups:
-      "NPM modules updates":
-        dependency-type: "production"
-      "NPM development modules updates":
-        dependency-type: "development"


### PR DESCRIPTION
This PR updates the Dependabot configuration to:
- Remove GitHub Actions updates
- Set open-pull-requests-limit to 0 for Go modules and NPM
- Remove groups configuration where present

These changes prevent Dependabot from creating automatic PRs for version updates while still allowing it to scan for vulnerabilities and create security updates when needed.