### PR TITLE
feat:381 highlight active topic

### DIFF
--- a/hugo/src/js/closest_map.js
+++ b/hugo/src/js/closest_map.js
@@ -1,0 +1,49 @@
+// helper class for finding the closest key in a map using binary search
+class ClosestMap {
+  /**
+   * @param {ClosestMapEntry[]} entries
+   */
+  constructor(entries = []) {
+    this.map = new Map(entries);
+    this._sortKeys();
+  }
+
+  /**
+   * Add a key-value pair to the map
+   * @param {number} key
+   * @param {*} value
+   */
+  add(key, value) {
+    this.map.set(key, value);
+    this._sortKeys();
+  }
+
+  _sortKeys() {
+    this.sortedKeys = [...this.map.keys()].sort((a, b) => a - b);
+  }
+
+  /**
+   * Get the value of the closest key less than or equal to the given key
+   * @param {number} key
+   * @returns {*|null} value or null
+   */
+  getFloor(key) {
+    let left = 0;
+    let right = this.sortedKeys.length - 1;
+    let result = null;
+
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2);
+      if (this.sortedKeys[mid] <= key) {
+        result = this.sortedKeys[mid];
+        left = mid + 1;
+      } else {
+        right = mid - 1;
+      }
+    }
+
+    return this.map.get(result);
+  }
+}
+
+export default ClosestMap;

--- a/hugo/src/scss/main.scss
+++ b/hugo/src/scss/main.scss
@@ -467,6 +467,9 @@ $jumbotron-arc-width: 120%;
         margin-left: $grid-gutter-width * 0.5;
       }
     }
+    li.active .podcast-topic-label {
+      font-style: italic;
+    }
     @include media-breakpoint-down('sm') {
       margin-top: $spacer * 1.5 !important;
       padding-top: $spacer * 1.5 !important;


### PR DESCRIPTION
feat #381 

Добавлено выделение активной темы. 

- Тема выделяется курсивом; если нужно, можно изменить цвет фона или использовать другие стили. 

- При загрузке страницы тема, на которой остановилось прослушивание, тоже выделяется.

- Поскольку активная тема проверяется часто, я добавил вспомогательный класс с бинарным поиском. 

Выглядит так:

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/4b3e8dca-f842-4f34-9554-0384d61fba77" />
