### PR TITLE
fix: podcast_content_controller follow-up from PR #484

### DIFF
--- a/hugo/.eslintignore
+++ b/hugo/.eslintignore
@@ -2,3 +2,4 @@ node_modules
 public
 dev
 static/build
+static/js

--- a/hugo/src/js/controllers/podcast_content_controller.js
+++ b/hugo/src/js/controllers/podcast_content_controller.js
@@ -14,9 +14,9 @@ export default class extends Controller {
 
     const postPodcast = this.element.closest('.post-podcast');
     const podcastTitleNumber = postPodcast?.querySelector('.podcast-title-number');
-    this.podcastNumber = Number(podcastTitleNumber?.innerText);
+    this.podcastNumber = podcastTitleNumber?.innerText?.trim() || null;
 
-    if (!Number.isFinite(this.podcastNumber)) {
+    if (!this.podcastNumber) {
       return;
     }
 
@@ -35,7 +35,7 @@ export default class extends Controller {
   }
 
   setInitialActiveTopic() {
-    if (!Number.isFinite(this.podcastNumber)) {
+    if (!this.podcastNumber) {
       return;
     }
 
@@ -82,6 +82,7 @@ export default class extends Controller {
 
   timeLabels() {
     this.topics = [];
+    this.activeTopic = null;
 
     function isEmpty(child) {
       return (
@@ -112,7 +113,7 @@ export default class extends Controller {
       while (li.lastChild && isEmpty(li.lastChild)) {
         li.lastChild.remove();
       }
-      if (li.childNodes && li.lastChild.nodeName === '#text') {
+      if (li.lastChild && li.lastChild.nodeName === '#text') {
         li.lastChild.textContent = li.lastChild.textContent.replace(/[\s\-.]+$/, '');
       }
 


### PR DESCRIPTION
Follow-up fixes for issues found during review of #484.

- **`activeTopic` stale reference on reconnect** — `timeLabels()` already resets `this.topics = []`; added `this.activeTopic = null` alongside it so reconnects don't carry a dangling DOM reference
- **`podcastNumber` type consistency** — changed from `Number(innerText)` to `innerText.trim()` (string), matching how every other controller handles the podcast number; removes the `Number.isFinite` guards in favour of a simple truthiness check
- **`li.lastChild` null guard** — `li.childNodes` is always truthy on an element node; changed to `li.lastChild` so the `.nodeName` access is properly guarded after the cleanup loop
- **ESLint CI failure** — `frontend-lint` has been failing on `static/js/chart.min.js` (vendored, minified) because `.eslintignore` only excluded `static/build`; added `static/js` to fix it