### PR TITLE
Escape RSS subtitle in a single pass

### DIFF
--- a/.github/workflows/ci-build-site.yml
+++ b/.github/workflows/ci-build-site.yml
@@ -112,13 +112,6 @@ jobs:
           prettier --write "${{ steps.set-dirs.outputs.old_dir }}/public/**/*.css"
           prettier --write "${{ steps.set-dirs.outputs.new_dir }}/public/**/*.css"
 
-      - name: Remove itunes:subtitle from RSS feeds before comparison
-        run: |
-          sed -i 's#<itunes:subtitle>.*</itunes:subtitle>##' ${{ steps.set-dirs.outputs.old_dir }}/public/podcast-archives-short.rss
-          sed -i 's#<itunes:subtitle>.*</itunes:subtitle>##' ${{ steps.set-dirs.outputs.new_dir }}/public/podcast-archives-short.rss
-          sed -i 's#<itunes:subtitle>.*</itunes:subtitle>##' ${{ steps.set-dirs.outputs.old_dir }}/public/podcast-archives.rss
-          sed -i 's#<itunes:subtitle>.*</itunes:subtitle>##' ${{ steps.set-dirs.outputs.new_dir }}/public/podcast-archives.rss
-
       - name: Remove hashes from CSS and JS files references
         run: |
           find ${{ steps.set-dirs.outputs.old_dir }}/public -type f -exec sed -i 's/\(js\|css\)?id=[^"'\''"]\+/\1/g' {} +

--- a/rss_generator/proc/generator.go
+++ b/rss_generator/proc/generator.go
@@ -286,19 +286,18 @@ func (g *RSSGenerator) htmlToPlainText(htmlContent string) (string, error) {
 	return res, nil
 }
 
+// xmlEscaper replaces characters special to XML with their entity references in a single pass,
+// so the entities it produces are not escaped again
+var xmlEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	`"`, "&quot;",
+	"'", "&apos;",
+)
+
 func (g *RSSGenerator) cleanStringForXML(input string) string {
-	replacements := map[string]string{
-		"&":  "&amp;",
-		"<":  "&lt;",
-		">":  "&gt;",
-		"\"": "&quot;",
-		"'":  "&apos;",
-	}
-	// iterate over the map and replace each character with its entity reference
-	for old, new := range replacements {
-		input = strings.ReplaceAll(input, old, new)
-	}
-	return input
+	return xmlEscaper.Replace(input)
 }
 
 func contains(slice []any, item any) bool {

--- a/rss_generator/proc/generator_test.go
+++ b/rss_generator/proc/generator_test.go
@@ -1,8 +1,11 @@
 package proc
 
 import (
+	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -477,4 +480,74 @@ func TestRSSGenerator_htmlToPlainText(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, result)
 	})
+}
+
+func TestRSSGenerator_cleanStringForXML(t *testing.T) {
+	g := RSSGenerator{}
+
+	tbl := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"nothing to escape", "Радио-Т 869", "Радио-Т 869"},
+		{"ampersand", "R&D", "R&amp;D"},
+		{"less than", "a < b", "a &lt; b"},
+		{"greater than", "a > b", "a &gt; b"},
+		{"double quote", `say "hi"`, "say &quot;hi&quot;"},
+		{"single quote", "Twitter теперь 'X'", "Twitter теперь &apos;X&apos;"},
+		{"all specials at once", `&<>"'`, "&amp;&lt;&gt;&quot;&apos;"},
+		{"entity produced by escaping is not escaped again", "'X' & 'Y'", "&apos;X&apos; &amp; &apos;Y&apos;"},
+		{"already escaped input is escaped once more", "&amp;", "&amp;amp;"},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, g.cleanStringForXML(tt.input))
+		})
+	}
+
+	t.Run("stable across repeated calls", func(t *testing.T) {
+		input := `Twitter теперь 'X' & "Y" <z>`
+		expected := g.cleanStringForXML(input)
+		for i := 0; i < 100; i++ {
+			assert.Equal(t, expected, g.cleanStringForXML(input), "call %d produced a different result", i)
+		}
+		assert.Equal(t, `Twitter теперь &apos;X&apos; &amp; &quot;Y&quot; &lt;z&gt;`, expected)
+	})
+}
+
+func TestRSSGenerator_SaveEscapedSubtitle(t *testing.T) {
+	g := RSSGenerator{RssRootLocation: t.TempDir()}
+
+	const subtitle = `Twitter теперь 'X' & "Y" <z>`
+	data := FeedData{
+		FeedTitle:       "Радио-Т",
+		FeedURL:         "https://radio-t.com",
+		FeedSubtitle:    "sub",
+		FeedDescription: "desc",
+		Items: []ItemData{{
+			Title:          "Радио-Т 869",
+			URL:            "https://radio-t.com/p/2023/12/23/podcast-869/",
+			GUID:           "https://radio-t.com/p//2023/12/23/podcast-869/",
+			Date:           "Sat, 23 Dec 2023 00:00:00 -0500",
+			EnclosureURL:   "https://cdn.radio-t.com/rt_podcast869.mp3",
+			ItunesSubtitle: g.cleanStringForXML(subtitle),
+		}},
+	}
+
+	require.NoError(t, g.Save(FeedConfig{Name: "test-feed"}, data))
+
+	res, err := os.ReadFile(filepath.Join(g.RssRootLocation, "test-feed.rss"))
+	require.NoError(t, err)
+
+	var parsed struct {
+		Items []struct {
+			Subtitle string `xml:"subtitle"`
+		} `xml:"channel>item"`
+	}
+	require.NoError(t, xml.Unmarshal(res, &parsed), "generated feed is not well-formed XML")
+	require.Len(t, parsed.Items, 1)
+	assert.Equal(t, subtitle, parsed.Items[0].Subtitle, "subtitle should decode back to the original text")
 }


### PR DESCRIPTION
`cleanStringForXML` built a `map[string]string` of replacements and ranged over it, so the order of `strings.ReplaceAll` calls differed between runs. When `'` was replaced before `&`, the `&apos;` it produced was escaped again into `&amp;apos;`.

Episode 869's title is `Twitter теперь 'X'`, and it falls into both `podcast-archives.rss` and `podcast-archives-short.rss`, so the same content produced different bytes on every build and feed consumers could get literal `&amp;apos;X&amp;apos;` text in `<itunes:subtitle>`.

`strings.NewReplacer` scans the input once and never re-examines what it wrote, so the five entity spellings stay as they were and the output is now canonical. The CI step that stripped `<itunes:subtitle>` from archive feeds before comparison existed only to hide this churn (df24bd89), so it is removed and the site build comparison sees subtitles again.

Tests: table-driven coverage for all five characters, already-escaped input, and stability across repeated calls, plus a `Save` round-trip that parses the generated feed as XML and checks the subtitle decodes back to the original text.