### PR TITLE
Set explicit GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/ci-build-publisher.yml
+++ b/.github/workflows/ci-build-publisher.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/ci-build-publisher.yml'
       - 'publisher/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build

--- a/.github/workflows/ci-build-site.yml
+++ b/.github/workflows/ci-build-site.yml
@@ -25,10 +25,16 @@ on:
       - '.github/FUNDING.yml'
       - 'hugo/content/**' # content likely won't break the build
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build-and-compare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # the build comparison result is posted as a PR comment
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-build-updater.yml
+++ b/.github/workflows/ci-build-updater.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/ci-build-updater.yml'
       - 'updater/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build

--- a/.github/workflows/ci-frontend-check.yml
+++ b/.github/workflows/ci-frontend-check.yml
@@ -10,9 +10,15 @@ on:
       - "hugo/**/*.tsx?"
       - "hugo/**/*.scss"
 
+permissions:
+  contents: read
+
 jobs:
   size:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # size-limit-action posts the bundle size report as a PR comment
     env:
       CI_JOB_NUMBER: 1
     steps:

--- a/.github/workflows/ci-frontend-lint.yml
+++ b/.github/workflows/ci-frontend-lint.yml
@@ -22,6 +22,9 @@ on:
       - "hugo/**/*.jsx?"
       - "hugo/**/*.tsx?"
 
+permissions:
+  contents: read
+
 jobs:
   frontend-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
None of the workflows declared `permissions`, so the token they run with is whatever the repository default grants, which is more than any of them needs and is what CodeQL flags.

Each workflow now starts from `contents: read`. Two jobs need more and declare it at job level:

- `build-and-compare` posts the site build comparison via `peter-evans/find-comment` and `peter-evans/create-or-update-comment` → `pull-requests: write`
- `size` passes `GITHUB_TOKEN` to `andresz1/size-limit-action`, which creates or updates the bundle size comment → `pull-requests: write`

The comparison job serves both `push` and `pull_request`, and permissions cannot be conditioned on the event, so the comment scope is granted on push runs too where it goes unused. Fork PRs are unaffected: their token is read-only regardless, which is why the comment step already carries `continue-on-error`.