### PR TITLE
Update GitHub Actions to current majors

### DIFF
--- a/.github/workflows/ci-build-publisher.yml
+++ b/.github/workflows/ci-build-publisher.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: build publisher image
       run: docker build -t radio-t/publisher .

--- a/.github/workflows/ci-build-site.yml
+++ b/.github/workflows/ci-build-site.yml
@@ -31,13 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Needed to fetch all history for comparison
 
       # for prettier as it's unknown how to build css and js without them being minimized
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -200,14 +200,14 @@ jobs:
           fi
 
       - name: Upload changes.diff as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: changes.diff
           path: changes.diff
           if-no-files-found: ignore
 
       - name: Upload changes.md as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: changes.md
           path: changes.md
@@ -269,14 +269,14 @@ jobs:
       - name: Find existing comment
         id: find-comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: "### Site Build Comparison"
 
       - name: Create or update comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         continue-on-error: true
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/ci-build-updater.yml
+++ b/.github/workflows/ci-build-updater.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: build updater image
       run: docker build -t radio-t/updater .

--- a/.github/workflows/ci-frontend-check.yml
+++ b/.github/workflows/ci-frontend-check.yml
@@ -17,13 +17,13 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # these steps are run in the size-limit-action anyway,
       # but exposed separately so that in case there is a problem not with the file size
       # but with the setup, we can see that failure clearly
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           cache: 'npm'

--- a/.github/workflows/ci-frontend-lint.yml
+++ b/.github/workflows/ci-frontend-lint.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -37,7 +37,7 @@ jobs:
       - run: npm ci --loglevel warn
         working-directory: hugo
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/hugo/node_modules/.cache
           key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- `actions/upload-artifact` v4 → v7
- `actions/cache` v4 → v6
- `peter-evans/find-comment` v3 → v4
- `peter-evans/create-or-update-comment` v4 → v5

Every input used here and the `comment-id` output still exist in the new majors. The behaviour changes in between do not touch this repo: `setup-node` v5 added automatic package-manager caching, but each call sets `cache: npm` explicitly; `upload-artifact` v7's unarchived upload is opt-in via `archive: false`; `checkout` v7 restricts fork checkout under `pull_request_target` and `workflow_run`, neither of which is used here. All of these majors run on Node 24 and need runner 2.327.1 or newer, which `ubuntu-latest` satisfies.

`andresz1/size-limit-action` stays at v1.8.0, its latest release.