### PR TITLE
Run publisher commands as argv instead of building a shell string

### DIFF
--- a/publisher/app/cmd/cmd.go
+++ b/publisher/app/cmd/cmd.go
@@ -18,6 +18,12 @@ type Executor interface {
 	Run(cmd string, params ...string)
 }
 
+// ShellExecutorIface runs commands and shell scripts, for callers which need both
+type ShellExecutorIface interface {
+	Executor
+	RunShell(script string)
+}
+
 // LastShow get the number of the latest published podcast via site-api
 // GET /last/{posts}?categories=podcast
 func LastShow(client http.Client, siteAPI string) (int, error) {
@@ -46,28 +52,41 @@ func LastShow(client http.Client, siteAPI string) (int, error) {
 	return showInfo[0].Num, nil
 }
 
-// ShellExecutor is a simple wrapper to execute command within shell
+// ShellExecutor runs commands, either as argv via Run or as a shell script via RunShell
 type ShellExecutor struct {
 	Dry bool
 }
 
-// Run makes the final command in printf style and panic on error
+// Run executes cmd with params passed as separate arguments, without a shell, and exits on error.
+// Values are never re-parsed, so paths and credentials may contain spaces and shell metacharacters.
 func (c *ShellExecutor) Run(cmd string, params ...string) {
-	command := fmt.Sprintf("%s %s", cmd, strings.Join(params, " "))
-	if err := c.do(command); err != nil {
+	log.Printf("[INFO] execute: %s %s", cmd, strings.Join(params, " ")) //nolint:gosec // the command is composed locally, log injection is not a concern for a CLI tool
+	if c.Dry {
+		return
+	}
+	ex := exec.Command(cmd, params...) //nolint:gosec // the command is composed by the caller, not by external input
+	if err := c.exec(ex, cmd); err != nil {
 		log.Printf("[ERROR] %v", err)
 		os.Exit(1) // failed cmd stops everything
 	}
 }
 
-// Do executes command and returns error if failed
-func (c *ShellExecutor) do(cmd string) error {
-	log.Printf("[INFO] execute: %s", cmd) //nolint:gosec // the command is composed locally, log injection is not a concern for a CLI tool
+// RunShell executes script with sh, for commands which need shell syntax, and exits on error.
+func (c *ShellExecutor) RunShell(script string) {
+	log.Printf("[INFO] execute: %s", script) //nolint:gosec // the script is composed locally, log injection is not a concern for a CLI tool
 	if c.Dry {
-		return nil
+		return
 	}
-	ex := exec.Command("sh", "-c", cmd) //nolint:gosec // running shell commands is what this executor is for
+	ex := exec.Command("sh", "-c", script) //nolint:gosec // running a shell script is what this method is for
+	if err := c.exec(ex, script); err != nil {
+		log.Printf("[ERROR] %v", err)
+		os.Exit(1) // failed cmd stops everything
+	}
+}
+
+// exec runs the prepared command, piping its output to the log
+func (c *ShellExecutor) exec(ex *exec.Cmd, descr string) error {
 	ex.Stdout = lgr.ToWriter(lgr.Default(), "INFO")
 	ex.Stderr = lgr.ToWriter(lgr.Default(), "WARN")
-	return errors.Wrapf(ex.Run(), "failed to run command: %s", cmd)
+	return errors.Wrapf(ex.Run(), "failed to run command: %s", descr)
 }

--- a/publisher/app/cmd/cmd_test.go
+++ b/publisher/app/cmd/cmd_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -34,14 +37,63 @@ func TestCmd_LastShowFailed(t *testing.T) {
 	assert.Contains(t, err.Error(), "can't get last shows")
 }
 
-func TestShellExecutor_do(t *testing.T) {
+func TestShellExecutor_exec(t *testing.T) {
 	c := ShellExecutor{}
-	err := c.do("ls -la")
-	assert.NoError(t, err)
 
-	err = c.do("ls -la && pwd")
-	assert.NoError(t, err)
+	t.Run("argv command", func(t *testing.T) {
+		assert.NoError(t, c.exec(exec.Command("ls", "-la"), "ls"))
+	})
 
-	err = c.do("lxxxxxxs -la")
-	assert.Error(t, err)
+	t.Run("shell script", func(t *testing.T) {
+		assert.NoError(t, c.exec(exec.Command("sh", "-c", "ls -la && pwd"), "ls && pwd"))
+	})
+
+	t.Run("missing command", func(t *testing.T) {
+		assert.Error(t, c.exec(exec.Command("lxxxxxxs", "-la"), "lxxxxxxs"))
+	})
+}
+
+func TestShellExecutor_Run(t *testing.T) {
+	c := ShellExecutor{}
+
+	t.Run("argument with spaces and metacharacters reaches the command intact", func(t *testing.T) {
+		dir := t.TempDir()
+		name := filepath.Join(dir, "a file $(id -un) `date`.txt")
+		c.Run("touch", name)
+		assert.FileExists(t, name, "the name must not be split or expanded on the way to touch")
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "exactly one file, no extra ones from a split argument")
+	})
+
+	t.Run("dry run executes nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		dry := ShellExecutor{Dry: true}
+		dry.Run("touch", filepath.Join(dir, "created.txt"))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+}
+
+func TestShellExecutor_RunShell(t *testing.T) {
+	t.Run("shell syntax still applies", func(t *testing.T) {
+		dir := t.TempDir()
+		c := ShellExecutor{}
+		c.RunShell("cd " + dir + " && touch one.txt && touch two.txt")
+		assert.FileExists(t, filepath.Join(dir, "one.txt"))
+		assert.FileExists(t, filepath.Join(dir, "two.txt"))
+	})
+
+	t.Run("dry run executes nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		dry := ShellExecutor{Dry: true}
+		dry.RunShell("touch " + filepath.Join(dir, "created.txt"))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
 }

--- a/publisher/app/cmd/deploy.go
+++ b/publisher/app/cmd/deploy.go
@@ -4,17 +4,17 @@ import (
 	"log"
 )
 
-//go:generate moq --out mocks/executor.go --pkg mocks --with-resets --skip-ensure . Executor
+//go:generate moq --out mocks/executor.go --pkg mocks --with-resets --skip-ensure . Executor ShellExecutorIface
 
 // Deploy delivers site update
 type Deploy struct {
-	Executor
+	ShellExecutorIface
 }
 
 // Do commits the site to git and performs a remote site update.
 func (d *Deploy) Do() {
 	log.Printf("[INFO] commit site to git")
-	d.Run(`git pull && git add . && git diff --staged --exit-code --quiet || git commit -m auto && git push`)
+	d.RunShell(`git pull && git add . && git diff --staged --exit-code --quiet || git commit -m auto && git push`)
 	log.Printf("[INFO] remote site update")
-	d.Run("ssh umputun@master.radio-t.com", `"cd /srv/radio-t/site.hugo && git pull && docker compose run --rm hugo"`)
+	d.Run("ssh", "umputun@master.radio-t.com", "cd /srv/radio-t/site.hugo && git pull && docker compose run --rm hugo")
 }

--- a/publisher/app/cmd/deploy_test.go
+++ b/publisher/app/cmd/deploy_test.go
@@ -10,18 +10,20 @@ import (
 )
 
 func TestDeploy_Do(t *testing.T) {
-	ex := &mocks.ExecutorMock{
-		RunFunc: func(_ string, _ ...string) {},
+	ex := &mocks.ShellExecutorIfaceMock{
+		RunFunc:      func(_ string, _ ...string) {},
+		RunShellFunc: func(_ string) {},
 	}
 
-	d := Deploy{Executor: ex}
+	d := Deploy{ShellExecutorIface: ex}
 	d.Do()
 
-	require.Equal(t, 2, len(ex.RunCalls()))
-	assert.Equal(t, `git pull && git add . && git diff --staged --exit-code --quiet || git commit -m auto && git push`, ex.RunCalls()[0].Cmd)
-	assert.Equal(t, 0, len(ex.RunCalls()[0].Params))
+	require.Equal(t, 1, len(ex.RunShellCalls()))
+	assert.Equal(t, `git pull && git add . && git diff --staged --exit-code --quiet || git commit -m auto && git push`,
+		ex.RunShellCalls()[0].Script)
 
-	assert.Equal(t, `ssh umputun@master.radio-t.com`, ex.RunCalls()[1].Cmd)
-	assert.Equal(t, 1, len(ex.RunCalls()[1].Params))
-	assert.Equal(t, `"cd /srv/radio-t/site.hugo && git pull && docker compose run --rm hugo"`, ex.RunCalls()[1].Params[0])
+	require.Equal(t, 1, len(ex.RunCalls()))
+	assert.Equal(t, "ssh", ex.RunCalls()[0].Cmd)
+	assert.Equal(t, []string{"umputun@master.radio-t.com",
+		"cd /srv/radio-t/site.hugo && git pull && docker compose run --rm hugo"}, ex.RunCalls()[0].Params)
 }

--- a/publisher/app/cmd/mocks/executor.go
+++ b/publisher/app/cmd/mocks/executor.go
@@ -88,3 +88,140 @@ func (mock *ExecutorMock) ResetCalls() {
 	mock.calls.Run = nil
 	mock.lockRun.Unlock()
 }
+
+// ShellExecutorIfaceMock is a mock implementation of cmd.ShellExecutorIface.
+//
+//	func TestSomethingThatUsesShellExecutorIface(t *testing.T) {
+//
+//		// make and configure a mocked cmd.ShellExecutorIface
+//		mockedShellExecutorIface := &ShellExecutorIfaceMock{
+//			RunFunc: func(cmd string, params ...string)  {
+//				panic("mock out the Run method")
+//			},
+//			RunShellFunc: func(script string)  {
+//				panic("mock out the RunShell method")
+//			},
+//		}
+//
+//		// use mockedShellExecutorIface in code that requires cmd.ShellExecutorIface
+//		// and then make assertions.
+//
+//	}
+type ShellExecutorIfaceMock struct {
+	// RunFunc mocks the Run method.
+	RunFunc func(cmd string, params ...string)
+
+	// RunShellFunc mocks the RunShell method.
+	RunShellFunc func(script string)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Run holds details about calls to the Run method.
+		Run []struct {
+			// Cmd is the cmd argument value.
+			Cmd string
+			// Params is the params argument value.
+			Params []string
+		}
+		// RunShell holds details about calls to the RunShell method.
+		RunShell []struct {
+			// Script is the script argument value.
+			Script string
+		}
+	}
+	lockRun      sync.RWMutex
+	lockRunShell sync.RWMutex
+}
+
+// Run calls RunFunc.
+func (mock *ShellExecutorIfaceMock) Run(cmd string, params ...string) {
+	if mock.RunFunc == nil {
+		panic("ShellExecutorIfaceMock.RunFunc: method is nil but ShellExecutorIface.Run was just called")
+	}
+	callInfo := struct {
+		Cmd    string
+		Params []string
+	}{
+		Cmd:    cmd,
+		Params: params,
+	}
+	mock.lockRun.Lock()
+	mock.calls.Run = append(mock.calls.Run, callInfo)
+	mock.lockRun.Unlock()
+	mock.RunFunc(cmd, params...)
+}
+
+// RunCalls gets all the calls that were made to Run.
+// Check the length with:
+//
+//	len(mockedShellExecutorIface.RunCalls())
+func (mock *ShellExecutorIfaceMock) RunCalls() []struct {
+	Cmd    string
+	Params []string
+} {
+	var calls []struct {
+		Cmd    string
+		Params []string
+	}
+	mock.lockRun.RLock()
+	calls = mock.calls.Run
+	mock.lockRun.RUnlock()
+	return calls
+}
+
+// ResetRunCalls reset all the calls that were made to Run.
+func (mock *ShellExecutorIfaceMock) ResetRunCalls() {
+	mock.lockRun.Lock()
+	mock.calls.Run = nil
+	mock.lockRun.Unlock()
+}
+
+// RunShell calls RunShellFunc.
+func (mock *ShellExecutorIfaceMock) RunShell(script string) {
+	if mock.RunShellFunc == nil {
+		panic("ShellExecutorIfaceMock.RunShellFunc: method is nil but ShellExecutorIface.RunShell was just called")
+	}
+	callInfo := struct {
+		Script string
+	}{
+		Script: script,
+	}
+	mock.lockRunShell.Lock()
+	mock.calls.RunShell = append(mock.calls.RunShell, callInfo)
+	mock.lockRunShell.Unlock()
+	mock.RunShellFunc(script)
+}
+
+// RunShellCalls gets all the calls that were made to RunShell.
+// Check the length with:
+//
+//	len(mockedShellExecutorIface.RunShellCalls())
+func (mock *ShellExecutorIfaceMock) RunShellCalls() []struct {
+	Script string
+} {
+	var calls []struct {
+		Script string
+	}
+	mock.lockRunShell.RLock()
+	calls = mock.calls.RunShell
+	mock.lockRunShell.RUnlock()
+	return calls
+}
+
+// ResetRunShellCalls reset all the calls that were made to RunShell.
+func (mock *ShellExecutorIfaceMock) ResetRunShellCalls() {
+	mock.lockRunShell.Lock()
+	mock.calls.RunShell = nil
+	mock.lockRunShell.Unlock()
+}
+
+// ResetCalls reset all the calls that were made to all mocked methods.
+func (mock *ShellExecutorIfaceMock) ResetCalls() {
+	mock.lockRun.Lock()
+	mock.calls.Run = nil
+	mock.lockRun.Unlock()
+
+	mock.lockRunShell.Lock()
+	mock.calls.RunShell = nil
+	mock.lockRunShell.Unlock()
+}

--- a/publisher/app/cmd/proc_mp3.go
+++ b/publisher/app/cmd/proc_mp3.go
@@ -64,8 +64,8 @@ func (p *Proc) Do(mp3file string) error {
 		return nil
 	}
 
-	newsAdminCreds := fmt.Sprintf("RT_NEWS_ADMIN:%q", os.Getenv("RT_NEWS_ADMIN"))
-	args := []string{"-p /etc/spot.yml", "-e mp3:" + mp3file, "-c 2", "-v", "-e", newsAdminCreds}
+	newsAdminCreds := "RT_NEWS_ADMIN:" + os.Getenv("RT_NEWS_ADMIN")
+	args := []string{"-p", "/etc/spot.yml", "-e", "mp3:" + mp3file, "-c", "2", "-v", "-e", newsAdminCreds}
 	if p.Dbg {
 		args = append(args, "--dbg")
 	}

--- a/publisher/app/cmd/proc_mp3_test.go
+++ b/publisher/app/cmd/proc_mp3_test.go
@@ -47,8 +47,8 @@ func TestProc_Do(t *testing.T) {
 
 	require.Equal(t, 1, len(ex.RunCalls()))
 	assert.Equal(t, "spot", ex.RunCalls()[0].Cmd)
-	assert.Equal(t, []string{"-p /etc/spot.yml", "-e mp3:/tmp/publisher_test/rt_podcast123/rt_podcast123.mp3",
-		"-c 2", "-v", "-e", `RT_NEWS_ADMIN:"test:123"`}, ex.RunCalls()[0].Params)
+	assert.Equal(t, []string{"-p", "/etc/spot.yml", "-e", "mp3:/tmp/publisher_test/rt_podcast123/rt_podcast123.mp3",
+		"-c", "2", "-v", "-e", "RT_NEWS_ADMIN:test:123"}, ex.RunCalls()[0].Params)
 }
 
 func TestProc_setMp3Tags(t *testing.T) {

--- a/publisher/app/main.go
+++ b/publisher/app/main.go
@@ -151,7 +151,7 @@ func runTags() {
 }
 
 func runDeploy() {
-	deploy := cmd.Deploy{Executor: &cmd.ShellExecutor{Dry: opts.Dry}}
+	deploy := cmd.Deploy{ShellExecutorIface: &cmd.ShellExecutor{Dry: opts.Dry}}
 	deploy.Do()
 	log.Printf("[INFO] site deployed")
 }


### PR DESCRIPTION
Part of #527, the publisher-host half of it. Not a full fix, see the note at the end.

`ShellExecutor.Run` joined the command and its arguments with spaces and handed the result to `sh -c`, so the shell re-parsed every value that passed through it. Two consequences, both reproduced on master:

- a directory name containing a space gave `spot` `mp3:/tmp/media` plus a stray `dir/rt_podcast999.mp3` argument
- `RT_NEWS_ADMIN` wrapped with `%q` was still expanded, so a password containing `$(...)` had that substitution executed on the publisher host and its output spliced into the credential

`Run` now executes argv directly. `Executor` keeps its existing single-method shape so `Proc` and any other implementation are unaffected; a wider `ShellExecutorIface` adds `RunShell` for callers that need shell syntax, and `Deploy` takes that one. Its git command still goes through a shell, since it relies on `&&` and `||`; the `ssh` command does not need one, so the remote command is passed as a single argument for the remote shell to interpret. The `spot` flags are split into separate arguments to match, and the credential no longer goes through `%q`.

New tests cover what the change is for: an argument containing spaces and `$(...)` reaching `touch` intact with no extra files created, shell syntax still working through `RunShell`, and both dry-run paths executing nothing.

`go build ./...`, `go test -race ./...` and `golangci-lint run ./...` are clean from `publisher/` now that #524 is merged.

### What this does not fix

Spot v1.16.4, pinned at `publisher/Dockerfile:35`, templates `${RT_NEWS_ADMIN}` into the `spot.yml` script before handing it to a shell on the target, so a credential containing `$(...)` or backticks is still substituted and executed one hop later, at `spot.yml:39`. The unquoted `$mp3` at `spot.yml:17-19` and the destination names at `spot.yml:31` are the same defect. The tests here stop at the mocked spot argv and do not cover any of that.

So #527 stays open for the Spot side. This PR is worth having on its own: every `Run` call in publisher is argv, and nothing reaches a local shell that is not a constant.
